### PR TITLE
Add required false for meta fields

### DIFF
--- a/src/Form/Type/ArticleTranslationType.php
+++ b/src/Form/Type/ArticleTranslationType.php
@@ -41,14 +41,17 @@ final class ArticleTranslationType extends AbstractResourceType
             ])
             ->add('metaTitle', TextType::class, [
                 'label' => 'monsieurbiz_blog.form.article.meta_title',
+                'required' => false,
                 'help' => 'monsieurbiz_blog.form.article.help.meta_title',
             ])
             ->add('metaDescription', TextType::class, [
                 'label' => 'monsieurbiz_blog.form.article.meta_description',
+                'required' => false,
                 'help' => 'monsieurbiz_blog.form.article.help.meta_description',
             ])
             ->add('metaKeywords', TextType::class, [
                 'label' => 'monsieurbiz_blog.form.article.meta_keywords',
+                'required' => false,
             ])
         ;
     }


### PR DESCRIPTION
Put meta fields as `required = false` because they are not required but were shown as required

### Before

<img width="1175" alt="Capture d’écran 2024-08-23 à 16 53 33" src="https://github.com/user-attachments/assets/f63a59da-ca4a-4e35-bd76-7b5a5a841146">

### After

<img width="1175" alt="Capture d’écran 2024-08-23 à 16 52 09" src="https://github.com/user-attachments/assets/72680b29-c421-429f-88cc-89f0beb4764e">
