### PR TITLE
TASK: add missing icons in choose target modal

### DIFF
--- a/src/Menu/BlogListUrlProvider.php
+++ b/src/Menu/BlogListUrlProvider.php
@@ -27,7 +27,7 @@ class BlogListUrlProvider extends AbstractUrlProvider
 
     protected string $code = self::PROVIDER_CODE;
 
-    protected string $icon = 'newspaper';
+    protected string $icon = 'tabler:news';
 
     protected int $priority = 35;
 

--- a/src/Menu/BlogUrlProvider.php
+++ b/src/Menu/BlogUrlProvider.php
@@ -25,7 +25,7 @@ class BlogUrlProvider extends AbstractUrlProvider
 
     protected string $code = self::PROVIDER_CODE;
 
-    protected string $icon = 'newspaper';
+    protected string $icon = 'tabler:article';
 
     protected int $priority = 25;
 

--- a/src/Menu/CaseStudyListUrlProvider.php
+++ b/src/Menu/CaseStudyListUrlProvider.php
@@ -27,7 +27,7 @@ class CaseStudyListUrlProvider extends AbstractUrlProvider
 
     protected string $code = self::PROVIDER_CODE;
 
-    protected string $icon = 'crosshairs';
+    protected string $icon = 'tabler:briefcase';
 
     protected int $priority = 30;
 

--- a/src/Menu/CaseStudyUrlProvider.php
+++ b/src/Menu/CaseStudyUrlProvider.php
@@ -25,7 +25,7 @@ class CaseStudyUrlProvider extends AbstractUrlProvider
 
     protected string $code = self::PROVIDER_CODE;
 
-    protected string $icon = 'crosshairs';
+    protected string $icon = 'tabler:file-analytics';
 
     protected int $priority = 20;
 


### PR DESCRIPTION
**Description**

This PR extends the UrlProviders by adding suitable icons for the modal for choosing a target:

<img width="501" height="236" alt="sylius_blog_plugin_choose_target_modal" src="https://github.com/user-attachments/assets/96e12512-a4d0-43e7-9611-19338f69fc7c" />
