### PR TITLE
Remove final from repositories

### DIFF
--- a/src/Repository/ArticleRepository.php
+++ b/src/Repository/ArticleRepository.php
@@ -20,7 +20,7 @@ use MonsieurBiz\SyliusBlogPlugin\Entity\TagInterface;
 use Sylius\Bundle\ResourceBundle\Doctrine\ORM\EntityRepository;
 use Sylius\Component\Channel\Model\ChannelInterface;
 
-final class ArticleRepository extends EntityRepository implements ArticleRepositoryInterface
+class ArticleRepository extends EntityRepository implements ArticleRepositoryInterface
 {
     public function createListQueryBuilderByType(string $localeCode, string $type): QueryBuilder
     {

--- a/src/Repository/AuthorRepository.php
+++ b/src/Repository/AuthorRepository.php
@@ -16,7 +16,7 @@ namespace MonsieurBiz\SyliusBlogPlugin\Repository;
 use Doctrine\ORM\QueryBuilder;
 use Sylius\Bundle\ResourceBundle\Doctrine\ORM\EntityRepository;
 
-final class AuthorRepository extends EntityRepository implements AuthorRepositoryInterface
+class AuthorRepository extends EntityRepository implements AuthorRepositoryInterface
 {
     public function createListQueryBuilder(): QueryBuilder
     {

--- a/src/Repository/TagRepository.php
+++ b/src/Repository/TagRepository.php
@@ -19,7 +19,7 @@ use MonsieurBiz\SyliusBlogPlugin\Entity\ArticleInterface;
 use MonsieurBiz\SyliusBlogPlugin\Entity\TagInterface;
 use Sylius\Bundle\ResourceBundle\Doctrine\ORM\EntityRepository;
 
-final class TagRepository extends EntityRepository implements TagRepositoryInterface
+class TagRepository extends EntityRepository implements TagRepositoryInterface
 {
     public function findRootNodes(): array
     {


### PR DESCRIPTION
Plugin repositories should be extensible within a project, just like any standard Sylius repository.

Declaring them as final prevents developers from extending them to reuse or customize their pre-defined methods.

This PR makes these repositories extensible, allowing them to be overridden as standard Sylius Resource repositories